### PR TITLE
Use @sinonjs/referee and add toString example

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,54 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@sinonjs/formatio": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-3.0.0.tgz",
+      "integrity": "sha512-vdjoYLDptCgvtJs57ULshak3iJe4NW3sJ3g36xVDGff5AE8P30S6A093EIEPjdi2noGhfuNOEkbxt3J3awFW1w==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/samsam": "2.1.0"
+      },
+      "dependencies": {
+        "@sinonjs/samsam": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-2.1.0.tgz",
+          "integrity": "sha512-5x2kFgJYupaF1ns/RmharQ90lQkd2ELS8A9X0ymkAAdemYHGtI2KiUHG8nX2WU0T1qgnOU5YMqnBM2V7NUanNw==",
+          "dev": true,
+          "requires": {
+            "array-from": "^2.1.1"
+          }
+        }
+      }
+    },
+    "@sinonjs/referee": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/referee/-/referee-2.6.0.tgz",
+      "integrity": "sha512-F8ArXQhYk1MrLDQgP0huv+6zbd1W3vsRhmDCQh9SHRTXMeFtIAKGQ4UmzXOAPciIPrJPrVkk2EM3a4PZcbPd2Q==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/formatio": "^3.0.0",
+        "@sinonjs/samsam": "^2.1.0",
+        "array-from": "2.1.1",
+        "bane": "^1.x",
+        "es6-promise": "^4.2.4",
+        "lodash.includes": "^4.3.0",
+        "lodash.isarguments": "^3.1.0",
+        "object-assign": "^4.1.1"
+      }
+    },
+    "@sinonjs/samsam": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-2.1.2.tgz",
+      "integrity": "sha512-ZwTHAlC9akprWDinwEPD4kOuwaYZlyMwVJIANsKNC3QVp0AHB04m7RnB4eqeWfgmxw8MGTzS9uMaw93Z3QcZbw==",
+      "dev": true
+    },
+    "array-from": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/array-from/-/array-from-2.1.1.tgz",
+      "integrity": "sha1-z+nYwmYoudxa7MYqn12PHzUsEZU=",
+      "dev": true
+    },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
@@ -57,6 +105,12 @@
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
       "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+      "dev": true
+    },
+    "es6-promise": {
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.5.tgz",
+      "integrity": "sha512-n6wvpdE43VFtJq+lUDYDBFUwV8TZbuGXLV4D6wKafg13ldznKsyEvatubnmUe31zcvelSzOHF+XbaT+Bl9ObDg==",
       "dev": true
     },
     "escape-string-regexp": {
@@ -119,10 +173,16 @@
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
       "dev": true
     },
-    "lodash": {
-      "version": "3.10.1",
-      "resolved": "http://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-      "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
+    "lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8=",
+      "dev": true
+    },
+    "lodash.isarguments": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=",
       "dev": true
     },
     "minimatch": {
@@ -174,6 +234,12 @@
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
       "dev": true
     },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "dev": true
+    },
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -185,25 +251,8 @@
     },
     "path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-      "dev": true
-    },
-    "referee": {
-      "version": "1.2.0",
-      "resolved": "http://registry.npmjs.org/referee/-/referee-1.2.0.tgz",
-      "integrity": "sha1-eneb7llVx4r/fYjAFhxaH0VFjJA=",
-      "dev": true,
-      "requires": {
-        "bane": "1.x",
-        "lodash": "3.x",
-        "samsam": "1.x"
-      }
-    },
-    "samsam": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.3.0.tgz",
-      "integrity": "sha512-1HwIYD/8UlOtFS3QO3w7ey+SdSDFE4HRNLZoZRYVQefrOY3l17epswImeB1ijgJFQJodIaHcwkp3r/myBjFVbg==",
       "dev": true
     },
     "supports-color": {

--- a/package.json
+++ b/package.json
@@ -8,10 +8,10 @@
     "url": "http://github.com/sinonjs/referee-custom-assert-with-mocha.git"
   },
   "scripts": {
-    "test": "mocha -r ./test/assertions/*"
+    "test": "mocha -r ./test/assertions/* ./test/*.test.js"
   },
   "devDependencies": {
-    "mocha": "^5.2.0",
-    "referee": "^1.2.0"
+    "@sinonjs/referee": "^2.6.0",
+    "mocha": "^5.2.0"
   }
 }

--- a/test/assertions/is-prime.js
+++ b/test/assertions/is-prime.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const referee = require("referee");
+const referee = require("@sinonjs/referee");
 
 // adapted from https://stackoverflow.com/a/40200710
 function isPrime(number){
@@ -17,9 +17,6 @@ referee.add("isPrime", {
         if (typeof actual !== "number" || actual < 0) {
             throw new TypeError("'actual' argument should be a non-negative Number");
         }
-
-        this.actual = actual;
-
         return isPrime(actual);
     },
     assertMessage: "Expected ${actual} to be a prime number",

--- a/test/assertions/to-string.js
+++ b/test/assertions/to-string.js
@@ -1,0 +1,23 @@
+"use strict";
+
+const referee = require("@sinonjs/referee");
+
+referee.add("toString", {
+  assert: function (actual, expected) {
+        if (typeof expected !== "string") {
+            throw new TypeError("'expected' argument should be a string");
+        }
+        return String(actual) === expected;
+    },
+    assertMessage: "${customMessage}Expected ${actual} to equal ${expected}",
+    refuteMessage: "${customMessage}Expected ${actual} not to equal ${expected}",
+    expectation: "toString",
+    values: function (actual, expected, message) {
+        return {
+            actual: String(actual),
+            expected: expected,
+            customMessage: message
+        };
+    }
+
+});

--- a/test/is-prime.test.js
+++ b/test/is-prime.test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { assert, refute } = require("referee");
+const { assert, refute } = require("@sinonjs/referee");
 
 describe("isPrime", function() {
     it("should have isPrime installed", function() {

--- a/test/is-prime.test.js
+++ b/test/is-prime.test.js
@@ -2,7 +2,7 @@
 
 const { assert, refute } = require("referee");
 
-describe("some", function() {
+describe("isPrime", function() {
     it("should have isPrime installed", function() {
         assert.isPrime(5);
         refute.isPrime(6);

--- a/test/to-string.test.js
+++ b/test/to-string.test.js
@@ -1,0 +1,10 @@
+'use strict';
+
+const { assert, refute } = require("@sinonjs/referee");
+
+describe("toString", function() {
+    it("should have toString installed", function() {
+        assert.toString([1, 2, 3], '1,2,3');
+        refute.toString([1, 2, 3], '3,2,1');
+    });
+});


### PR DESCRIPTION
A few small things in one PR:

- Changes the dependency from `referee` to `@sinonjs/referee` to match what is said in the readme and address security warnings.
- Rename `some.test.js` to `is-prime.test.js`
- Make `npm test` actually run the tests (default wildcard is `test/*-test.js`).
- Add a `toString` example.